### PR TITLE
Adding keepalive action step to end of live runs to stop GitHub automatically disabling the workflow

### DIFF
--- a/.github/workflows/orphan-cleanup.yaml
+++ b/.github/workflows/orphan-cleanup.yaml
@@ -2,7 +2,7 @@ name: orphaned-resource-cleanup
 
 on:
   workflow_dispatch:
-   inputs:
+    inputs:
       dryRunEnabled:
         description: 'Enable Dry-Run Mode'
         required: true
@@ -23,7 +23,7 @@ jobs:
       - name: 'Az CLI login'
         uses: azure/login@v2
         with:
-          client-id: c670b53f-74bc-4fa8-82c6-5577e8600d2a # DTSPO Orphaned Resource Cleanup 
+          client-id: c670b53f-74bc-4fa8-82c6-5577e8600d2a # DTSPO Orphaned Resource Cleanup
           tenant-id: 531ff96d-0ae9-462a-8d2d-bec7c0b42082 # HMCTS.NET
           allow-no-subscriptions: true
       - name: Get slack webhook secret
@@ -38,7 +38,7 @@ jobs:
           done
       - name: Dry Run orphaned resources in Azure
         run: ./scripts/orphan-cleanup.sh -m dry-run ${{ steps.slack-webhook.outputs.orphaned-resources-slack-webhook }} dtspo-orphaned-resource-cleanup
-  
+
   live:
     runs-on: ubuntu-latest
     permissions:
@@ -65,3 +65,5 @@ jobs:
           done
       - name: Delete orphaned resources in Azure
         run: ./scripts/orphan-cleanup.sh ${{ steps.slack-webhook.outputs.orphaned-resources-slack-webhook }} dtspo-orphaned-resource-cleanup
+      - name: 'reset keepalive timer'
+        uses: gautamkrishnar/keepalive-workflow@v2

--- a/.github/workflows/orphan-cleanup.yaml
+++ b/.github/workflows/orphan-cleanup.yaml
@@ -65,5 +65,3 @@ jobs:
           done
       - name: Delete orphaned resources in Azure
         run: ./scripts/orphan-cleanup.sh ${{ steps.slack-webhook.outputs.orphaned-resources-slack-webhook }} dtspo-orphaned-resource-cleanup
-      - name: 'reset keepalive timer'
-        uses: gautamkrishnar/keepalive-workflow@v2

--- a/.github/workflows/reset-workflow-timeout.yaml
+++ b/.github/workflows/reset-workflow-timeout.yaml
@@ -1,0 +1,17 @@
+name: Keep scheduled jobs running
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+# Prevent scheduled jobs being disabled after 60 days
+# see https://github.community/t/no-notification-workflow-disabled-after-60-days/182169
+# existing GitHub notifications don't seem to work at all
+# this should trigger a dummy commit to the default branch every 50 days
+jobs:
+  keepalive:
+    name: Keep scheduled jobs running
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gautamkrishnar/keepalive-workflow@1.0.7

--- a/.github/workflows/reset-workflow-timeout.yaml
+++ b/.github/workflows/reset-workflow-timeout.yaml
@@ -13,5 +13,6 @@ jobs:
     name: Keep scheduled jobs running
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: gautamkrishnar/keepalive-workflow@1.0.7
+      - uses: actions/checkout@v4
+      - name: 'reset keepalive timer'
+        uses: gautamkrishnar/keepalive-workflow@v2

--- a/.github/workflows/reset-workflow-timeout.yaml
+++ b/.github/workflows/reset-workflow-timeout.yaml
@@ -5,9 +5,6 @@ on:
     - cron: "0 0 * * *"
 
 # Prevent scheduled jobs being disabled after 60 days
-# see https://github.community/t/no-notification-workflow-disabled-after-60-days/182169
-# existing GitHub notifications don't seem to work at all
-# this should trigger a dummy commit to the default branch every 50 days
 jobs:
   keepalive:
     name: Keep scheduled jobs running


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-16002

### Change description ###
Adding keepalive action step to end of live runs to stop GitHub automatically disabling the workflow
